### PR TITLE
re-use more layers 

### DIFF
--- a/edge/Dockerfile
+++ b/edge/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:edge
-RUN apk add --no-cache curl
-COPY entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["curl"]
+RUN apk add --no-cache curl
+COPY entrypoint.sh /

--- a/edge/Dockerfile
+++ b/edge/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:edge
-RUN apk add --update curl && rm -rf /var/cache/apk/*
+RUN apk add --no-cache curl
 COPY entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["curl"]

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-RUN apk add --update curl && rm -rf /var/cache/apk/*
+RUN apk add --no-cache curl
 COPY entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["curl"]

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-RUN apk add --no-cache curl
-COPY entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["curl"]
+RUN apk add --no-cache curl
+COPY entrypoint.sh /


### PR DESCRIPTION
Move ENTRYPOINT and CMD earlier in the Dockerfile so layers are reused more often.

Also use `--no-cache` flag instead of manually deleting /var/cache/apk